### PR TITLE
【確認待ち】CSS Optimize の変数名を変更

### DIFF
--- a/src/VkCssOptimize.php
+++ b/src/VkCssOptimize.php
@@ -233,7 +233,7 @@ class VkCssOptimize {
 
 		$theme_textdomain = wp_get_theme()->get( 'TextDomain' );
 
-		// CSS高速化を各テーマなどで保存していた頃の互換処理.
+		// CSS高速化を各テーマなどのoption側で保存していた頃の互換処理.
 		if ( 'lightning' === $theme_textdomain || 'lightning-pro' === $theme_textdomain ) {
 			$old_options = get_option( 'lightning_theme_options' );
 		} elseif ( 'katawara' === $theme_textdomain ) {
@@ -249,6 +249,7 @@ class VkCssOptimize {
 		if ( ! isset( $vk_css_optimize_options['tree_shaking'] ) ) {
 			// 古い設定がある場合（互換処理）.
 			if ( isset( $old_options['optimize_css'] ) ) {
+				// 古い設定でCSS最適化が有効だった場合.
 				if ( 'optomize-all-css' === $old_options['optimize_css'] || 'tree-shaking' === $old_options['optimize_css'] ) {
 					$vk_css_optimize_options['tree_shaking'] = 'active';
 				} else {
@@ -261,6 +262,7 @@ class VkCssOptimize {
 		if ( ! isset( $vk_css_optimize_options['tree_shaking_class_exclude'] ) ) {
 			// 古いoption値で除外指定が存在する場合（互換処理）.
 			if ( ! empty( $old_options['tree_shaking_class_exclude'] ) ) {
+				// 古いoption値に保存されている除外指定を新しいoption値に格納.
 				$vk_css_optimize_options['tree_shaking_class_exclude'] = esc_html( $old_options['tree_shaking_class_exclude'] );
 			}
 		}
@@ -269,6 +271,7 @@ class VkCssOptimize {
 		if ( ! isset( $vk_css_optimize_options['preload'] ) ) {
 			// 古いoption値でプリロード設定が存在する場合（互換処理）.
 			if ( isset( $old_options['optimize_css'] ) ) {
+				// 古いoption値に保存されているプリロード指定を新しいoption値に格納.
 				if ( 'optomize-all-css' === $old_options['optimize_css'] ) {
 					$vk_css_optimize_options['preload'] = 'active';
 				} else {
@@ -277,6 +280,7 @@ class VkCssOptimize {
 			}
 		}
 		$vk_css_optimize_options = wp_parse_args( $vk_css_optimize_options, $vk_css_optimize_options_default );
+
 		if (
 			! isset( $vk_css_optimize_options['tree_shaking'] ) ||
 			! isset( $vk_css_optimize_options['tree_shaking_class_exclude'] ) ||


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

- VK_CSS_Optimize 内の変数名で css_tree_shaking_handles に対し css_simple_minify_array は疑問

## どういう変更をしたか？

- VK_CSS_Optimize 内の変数名を見直し
- この変更に関わるのは現状 Swiper のみだがそれについても [Composer 版](https://github.com/vektor-inc/vk-swiper)では対応済み


## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？
=> ソースコードを見れば反映されていることがわかるので不要かと

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

1. Lightning を有効化しすべてのプラグインを無効化
2. composer で下記を読み込むようにして composer install
```
"vektor-inc/vk-css-optimize": "dev-fix/array-to-handle",
"vektor-inc/vk-swiper": "dev-main"
```
3. TreeShaking を ON にすると lightning-common-style と lightning-design-style と vk-swiper-style が直接出力されるのを確認
4. Preload を ON にすると上記以外の CSS に Preload が適用されるのを確認

## 確認URL

ローカル環境でお願いします。

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

1. Lightning を有効化しすべてのプラグインを無効化
2. composer で下記を読み込むようにして composer install
```
"vektor-inc/vk-css-optimize": "dev-fix/array-to-handle",
"vektor-inc/vk-swiper": "dev-main"
```
3. TreeShaking を ON にすると lightning-common-style と lightning-design-style と vk-swiper-style が直接出力されるのを確認
4. Preload を ON にすると上記以外の CSS に Preload が適用されるのを確認

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？