### PR TITLE
【確認待ち】CSS のオプションへの格納を廃止

### DIFF
--- a/src/VkCssOptimize.php
+++ b/src/VkCssOptimize.php
@@ -224,7 +224,12 @@ class VkCssOptimize {
 	 * CSS Optimize Options
 	 * 古いオプションやデフォルト値を結合して返す
 	 *
-	 * @return array $vk_css_optimize_options .
+	 * @return array{
+	 *   tree_shaking: string,
+	 *   tree_shaking_class_exclude: string,
+	 *   preload: string
+	 *   preload_handle_exclude: string
+	 * } $vk_css_optimize_options.
 	 */
 	public static function get_css_optimize_options() {
 
@@ -278,9 +283,12 @@ class VkCssOptimize {
 		}
 
 		// オプション値に格納するのは不要と見て削除
-		if ( ! empty( $vk_css_optimize_options['tree_shaking_css'] ) || ! empty( $vk_css_optimize_options['simple_minify_css' ] ) ) {
+		// ここで削除している tree_shaking_css や simple_minify_css は古いバージョンで保存されたもので、
+		// 不要になったため。2023.6末以降あたり削除で良いと思われる
+		// @since 0.2.0 .
+		if ( ! empty( $vk_css_optimize_options['tree_shaking_css'] ) || ! empty( $vk_css_optimize_options['simple_minify_css'] ) ) {
 			unset( $vk_css_optimize_options['tree_shaking_css'] );
-			unset( $vk_css_optimize_options['simple_minify_css' ] );
+			unset( $vk_css_optimize_options['simple_minify_css'] );
 		}
 
 		$vk_css_optimize_options = wp_parse_args( $vk_css_optimize_options, $vk_css_optimize_options_default );

--- a/src/VkCssOptimize.php
+++ b/src/VkCssOptimize.php
@@ -214,8 +214,8 @@ class VkCssOptimize {
 	 */
 	public static function get_css_optimize_options_default() {
 		$vk_css_optimize_options_default = array(
-			'tree_shaking'      => '',
-			'preload'           => '',
+			'tree_shaking' => '',
+			'preload'      => '',
 		);
 		return apply_filters( 'vk_css_optimize_options_default', $vk_css_optimize_options_default );
 	}
@@ -353,9 +353,9 @@ class VkCssOptimize {
 		global $wp_styles;
 		$registerd = $wp_styles->registered;
 
-		$options                = array();
-		$tree_shaking_handles   = self::css_tree_shaking_handles();
-		$simple_minify_handles  = self::css_simple_minify_handles();
+		$options               = array();
+		$tree_shaking_handles  = self::css_tree_shaking_handles();
+		$simple_minify_handles = self::css_simple_minify_handles();
 
 		// tree_shaking用の情報を生成.
 		foreach ( $tree_shaking_handles as $css_handle ) {
@@ -460,9 +460,9 @@ class VkCssOptimize {
 			// ↓↓↓↓↓↓↓↓↓↓↓ 必要性不明のためコメントアウト 2023.06.30 以降削除可
 			// ファイルで読み込んでいるCSSを直接出力に置換（バージョンパラメーターなし）.
 			// $buffer = str_replace(
-			// 	'<link rel=\'stylesheet\' id=\'' . $handle . '-css\' href=\'' . $href . '\' media=\'print\' onload=\"this.media=\'all\'; this.onload=null;\">',
-			// 	'',
-			// 	$buffer
+			// '<link rel=\'stylesheet\' id=\'' . $handle . '-css\' href=\'' . $href . '\' media=\'print\' onload=\"this.media=\'all\'; this.onload=null;\">',
+			// '',
+			// $buffer
 			// );
 
 		}
@@ -510,8 +510,8 @@ class VkCssOptimize {
 
 		// Load CSS Arrays
 		// 軽量化するCSSの情報配列読み込み.
-		$tree_shaking_handles   = self::css_tree_shaking_handles();
-		$simple_minify_handles  = self::css_simple_minify_handles();
+		$tree_shaking_handles  = self::css_tree_shaking_handles();
+		$simple_minify_handles = self::css_simple_minify_handles();
 
 		$exclude_handles = array( 'woocommerce-layout', 'woocommerce-smallscreen', 'woocommerce-general' );
 
@@ -526,7 +526,7 @@ class VkCssOptimize {
 		// Simple Minify がかかっているものはpreloadから除外する ////////////////////
 		// ※ 除外しないと表示時に一瞬崩れて結局実用性に問題があるため.
 
-		foreach ($simple_minify_handles as $css_handles ) {
+		foreach ( $simple_minify_handles as $css_handles ) {
 			// ハンドル名をプリロード除外リストに追加.
 			$exclude_handles[] = $css_handles;
 		}

--- a/src/VkCssOptimize.php
+++ b/src/VkCssOptimize.php
@@ -275,7 +275,7 @@ class VkCssOptimize {
 		}
 
 		// オプション値に格納するのは不要と見て削除
-		if ( $vk_css_optimize_options['tree_shaking_css'] || $vk_css_optimize_options['simple_minify_css' ] ) {
+		if ( ! empty( $vk_css_optimize_options['tree_shaking_css'] ) || ! empty( $vk_css_optimize_options['simple_minify_css' ] ) ) {
 			unset( $vk_css_optimize_options['tree_shaking_css'] );
 			unset( $vk_css_optimize_options['simple_minify_css' ] );
 		}


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

- オプションに保存するのが必要か否かに疑問を感じた( https://github.com/vektor-inc/vk-css-optimize/issues/4 )

## どういう変更をしたか？

- オプションに保存するのが必要か否かに疑問を感じたので一旦なしに

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？
=> ソースコードを見れば反映されていることがわかるので不要かと

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

1. Lightning を有効化しすべてのプラグインを無効化
2. composer で下記を読み込むようにして composer install
```
"vektor-inc/vk-css-optimize": "dev-fix/no-option",
```
3. TreeShaking を ON にすると lightning-common-style と lightning-design-style  に TreeShaking が適用されるのを確認
4. Preload を ON にすると上記以外の CSS に Preload が適用されるのを確認

## 確認URL

ローカル環境でお願いします。

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

1. Lightning を有効化しすべてのプラグインを無効化
2. composer で下記を読み込むようにして composer install
```
"vektor-inc/vk-css-optimize": "dev-fix/no-option",
```
3. TreeShaking を ON にすると lightning-common-style と lightning-design-style  に TreeShaking が適用されるのを確認
4. Preload を ON にすると上記以外の CSS に Preload が適用されるのを確認

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
