### PR TITLE
【イシカワ確認待ち】Tree Shaking を 3.2 に更新 

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ npx playwright test --project=chromium --trace on
 
 ## Change log
 
+[ その他 ] Tree Shaking アップデート 3.2.0
+
 0.2.5
 [ 不具合修正 ] VK Blocks 1.85 からテーブルのスクロールヒントのCSSが TreeShaking で正しく処理できず、その影響で非表示クラスが効かなくなるなどの不具合が発生するため、見た目の不具合回避のために応急処置として強制的に TreeShaking を無効化
 

--- a/src/VkCssOptimize.php
+++ b/src/VkCssOptimize.php
@@ -488,7 +488,7 @@ class VkCssOptimize {
 					'btn',
 					'btn-primary',
 				);
-				$jsaddlist = apply_filters( 'css_tree_shaking_js_added_classes', $jsaddlist );
+				$jsaddlist = apply_filters( 'css_tree_shaking_js_added_class', $jsaddlist );
 
 				// CSS の中身が取得できた場合のみ Tree Shaking を反映する
 				if ( ! empty( $css ) ) {

--- a/src/VkCssOptimize.php
+++ b/src/VkCssOptimize.php
@@ -488,7 +488,7 @@ class VkCssOptimize {
 					'btn',
 					'btn-primary',
 				);
-				$jsaddlist = apply_filters( 'css_tree_shaking_exclude', $jsaddlist );
+				$jsaddlist = apply_filters( 'css_tree_shaking_exclude_classes', $jsaddlist );
 
 				// CSS の中身が取得できた場合のみ Tree Shaking を反映する
 				if ( ! empty( $css ) ) {

--- a/src/VkCssOptimize.php
+++ b/src/VkCssOptimize.php
@@ -488,6 +488,7 @@ class VkCssOptimize {
 					'btn',
 					'btn-primary',
 				);
+				$jsaddlist = apply_filters( 'css_tree_shaking_exclude', $jsaddlist );
 				$jsaddlist = apply_filters( 'css_tree_shaking_js_added_class', $jsaddlist );
 
 				// CSS の中身が取得できた場合のみ Tree Shaking を反映する

--- a/src/VkCssOptimize.php
+++ b/src/VkCssOptimize.php
@@ -309,12 +309,6 @@ class VkCssOptimize {
 			update_option( 'vk_css_optimize_options', $vk_css_optimize_options );
 		}
 
-		// 0.2.5
-		// VK Blocks 1.85 からテーブルのスクロールヒントのCSSが TreeShaking で正しく処理できず、
-		// その影響で非表示クラスが効かなくなるなどの不具合が発生するため、
-		// 見た目の不具合回避のために応急処置として強制的に TreeShaking を無効化
-		$vk_css_optimize_options['tree_shaking'] = '';
-
 		return $vk_css_optimize_options;
 	}
 
@@ -473,10 +467,33 @@ class VkCssOptimize {
 					$css = $wp_filesystem->get_contents( $path_name );
 				}
 
+				$jsaddlist = array(
+					'device-mobile',
+					'header_scrolled',
+					'active',
+					'menu-open',
+					'vk-mobile-nav-menu-btn',
+					'vk-mobile-nav-open',
+					'vk-menu-acc-active',
+					'acc-parent-open',
+					'acc-btn',
+					'acc-btn-open',
+					'acc-btn-close',
+					'acc-child-open',
+					'carousel-item-left',
+					'carousel-item-next',
+					'carousel-item-right',
+					'carousel-item-prev',
+					'form-control',
+					'btn',
+					'btn-primary',
+				);
+				$jsaddlist = apply_filters( 'css_tree_shaking_exclude', $jsaddlist );
+
 				// CSS の中身が取得できた場合のみ Tree Shaking を反映する
 				if ( ! empty( $css ) ) {
 					// tree shaking を実行して再格納 .
-					$css = CSS_tree_shaking::extended_minify( CSS_tree_shaking::simple_minify( $css ), $buffer );
+					$css = CSS_tree_shaking::extended_minify( CSS_tree_shaking::simple_minify( $css ), $buffer, $jsaddlist );
 
 					// ファイルで読み込んでいるCSSを直接出力に置換（バージョンパラメーターあり）.
 					$buffer = str_replace(
@@ -611,9 +628,9 @@ class VkCssOptimize {
 	/**
 	 * Exclude CSS.
 	 *
-	 * @param string $inidata exclude css class.
+	 * @param string $jsaddlist exclude css class.
 	 */
-	public static function tree_shaking_exclude( $inidata ) {
+	public static function tree_shaking_exclude( $jsaddlist ) {
 		$options = self::get_css_optimize_options();
 
 		$exclude_classes_array = array();
@@ -634,8 +651,8 @@ class VkCssOptimize {
 
 		}
 
-		$inidata['class'] = array_merge( $inidata['class'], $exclude_classes_array );
+		$jsaddlist = array_merge( $jsaddlist, $exclude_classes_array );
 
-		return $inidata;
+		return $jsaddlist;
 	}
 }

--- a/src/VkCssOptimize.php
+++ b/src/VkCssOptimize.php
@@ -488,7 +488,7 @@ class VkCssOptimize {
 					'btn',
 					'btn-primary',
 				);
-				$jsaddlist = apply_filters( 'css_tree_shaking_exclude_classes', $jsaddlist );
+				$jsaddlist = apply_filters( 'css_tree_shaking_js_added_classes', $jsaddlist );
 
 				// CSS の中身が取得できた場合のみ Tree Shaking を反映する
 				if ( ! empty( $css ) ) {

--- a/src/VkCssOptimize.php
+++ b/src/VkCssOptimize.php
@@ -20,7 +20,7 @@ class VkCssOptimize {
 	 */
 	public function __construct() {
 		add_action( 'customize_register', array( __CLASS__, 'customize_register' ) );
-		add_filter( 'css_tree_shaking_exclude', array( __CLASS__, 'tree_shaking_exclude' ) );
+		add_filter( 'css_tree_shaking_js_added_class', array( __CLASS__, 'tree_shaking_js_added_class' ) );
 
 		$options = self::get_css_optimize_options();
 
@@ -630,7 +630,7 @@ class VkCssOptimize {
 	 *
 	 * @param string $jsaddlist exclude css class.
 	 */
-	public static function tree_shaking_exclude( $jsaddlist ) {
+	public static function tree_shaking_js_added_class( $jsaddlist ) {
 		$options = self::get_css_optimize_options();
 
 		$exclude_classes_array = array();

--- a/src/class-css-tree-shaking.php
+++ b/src/class-css-tree-shaking.php
@@ -1,377 +1,216 @@
 <?php
 /**
  * CSS Simple Tree Shaking
- *
+ * 
  * Description: CSS tree shaking minify library
- *
- * Version: 2.2.0
+ * Version: 3.2.0
  * Author: enomoto@celtislab
  * Author URI: https://celtislab.net/
- * License: GPLv2
- *
+ * License: GPLv2 
  */
+
  // namesupace は変更しないと celtislab のプラグインなどと干渉して誤動作する可能性があるため変更.
  namespace VektorInc\VK_CSS_Optimize;
 
 defined( 'ABSPATH' ) || exit;
 
-
 class CSS_tree_shaking {
-
-    private static $cmplist;
+    
+    private static $is_parse;
+    private static $tag;
+    private static $id;
+    private static $class;
+    private static $style;
+    private static $type;
+    private static $role;
+    private static $attrlist;
     private static $jsaddlist;
-
-    const  SHAKING_PATTERN = '#@(?<pref>\-[\w]+\-)?(?<atname>((keyframes|supports|media|container|layer)[^\{]+?))\{(?<atstyle>.*?\})\}|@([^;\{\}]+?)(;|\{.*?\})|(?<sel>.+?)\{(?<pv>.+?)\}#u';
 
 	function __construct() {}
 
-    //上書きカスタムCSS(simple_minify済)をセレクタ(md5),プロパティ,値の配列にする
-    //※セレクタが複数の場合も考慮して完全同一記述のセレクタのみを簡潔に重複判定出来るよう md5 を使用
-    public static function create_csslist($cusomcss, &$csslist) {
-        if(preg_match_all( self::SHAKING_PATTERN, $cusomcss, $matches, PREG_SET_ORDER)){
-            foreach ($matches as $style) {
-                if(!empty($style['atname'])){
-                    $atkey = md5(trim($style['pref'] . $style['atname']));
-                    if(preg_match_all( '#(?<sel>.+?)\{(?<pv>.+?)\}#u', $style['atstyle'], $atcustoms, PREG_SET_ORDER)){
-                        foreach ($atcustoms as $subitem) {
-                            self::_create_csslist($atkey, $subitem['sel'], $subitem['pv'], $csslist);
-                        }
-                    }
-                } elseif(!empty($style['sel'])) {
-                    self::_create_csslist(0, $style['sel'], $style['pv'], $csslist);
-                }
+    //Remove CSS data including unused id / class / tag
+    private static function tree_shaking($css) {
+        $mincss = preg_replace_callback( '`(?<sel>[^{]+?)\{(?<pv>.*)\}(?<after>[^}]*$)`u', function($mstyle) {            
+            $before = '';
+            $sel    = $mstyle['sel'];                    
+            if(false !== ($sep = strrpos($sel, ';'))){
+                $before = substr($sel, 0, $sep + 1);
+                $sel    = substr($sel, $sep + 1);
             }
-        }
-    }
-    private static function _create_csslist($key, $sel, $pv, &$csslist) {
-        $sel = md5(trim($sel));
-        $pv  = array_map("trim", preg_split("|[:;]|", $pv));
-        $pcnt= count($pv);
-        for($i=0; $i<$pcnt; $i += 2){
-            if(empty($pv[$i]))
-                break;
-            $csslist[ $key ][ $sel ][ $pv[$i] ] = $pv[$i+1];
-        }
-    }
-
-    //selector 内の :not :where :is :has 疑似クラスを退避(カッコ内の,区切りによるセレクタ誤解析回避のため)
-    public static function evacuate_pseudo($selector, &$temp) {
-        $newsel = '';
-        $ofset = 0;
-        $maxlen = strlen($selector);
-        while($ofset < $maxlen){
-            if(preg_match('#(:not|:where|:is|:has)\(#u', substr($selector, $ofset), $omatch)){
-                $open = strpos($selector, $omatch[0], $ofset) + strlen($omatch[0]);
-                if($ofset < $open){
-                    $newsel .= substr($selector, $ofset, $open - $ofset);
-                }
-                $ofset = $open;
-                $depth = 1;
-                while($depth > 0){
-                    if(preg_match('#(\(|\))#u', substr($selector, $ofset), $cmatch)){
-                        $ofset = strpos($selector, $cmatch[0], $ofset) + strlen($cmatch[0]);
-                        if($cmatch[1] == '('){
-                            $depth++;
-                        } else{
-                            $depth--;
-                        }
-                        if($depth === 0){
-                            $replace = substr($selector, $open, $ofset - $open - 1);
-                            $pskey = md5($replace);
-                            $temp[$pskey] = $replace;
-                            $newsel .= $pskey . ')';
-                        }
-                    } else {
-                        $newsel .= substr($selector, $ofset);
-                        $ofset = $maxlen;
-                        break;
+            $pv     = $mstyle['pv'];
+            $after  = $mstyle['after'];
+            
+            //Remove unused selectors
+            $_sel = (strpos($sel, '(') !== false)? preg_replace_callback( '`\((((?>[^()]+)|(?R))*)\)`', function($rep){ return str_replace(',', "\t", $rep[0]); }, $sel) : $sel;
+            array_map( function($s) use(&$sel){
+                if(empty($s) || strpos($s, '@') !== false){
+                    //Skip @ at-rule
+                } else {
+                    //Skip pseudo-classes that can describe selectors for simplification (determine by $_s and target $s when deleting)
+                    //Except for :not, the evaluation does not exclude elements with a single element.
+                    $_s = $s;
+                    if(strpos($s, '(') !== false){
+                        $_s = preg_replace_callback( '`(:not|:where|:is|:has)(\(((?>[^()]+)|(?2))*\))`', function($pseudo){
+                                return ($pseudo[1] !== ':not' && strpos($pseudo[2], ',') === false)? preg_replace( '`(:not)(\(((?>[^()]+)|(?2))*\))`', '', $pseudo[0]) : '';
+                            }, str_replace("\t", ',', $s) );
+                            
+                        //Skip nth- pseudo-elements such as :nth-child(odd) (to prevent the tag from recognizing what is inside the parentheses)
+                        $_s = preg_replace_callback( '`:nth[^)]+\)`', function($pseudo){
+                                return '';
+                            }, $_s );
                     }
+
+                    $offset = 0;
+                    $maxlen = strlen($_s);
+                    while($offset < $maxlen && preg_match( '`(?<id>#)(?<iname>[\w\-\\%]+)|(?<class>\.)(?<cname>[\w\-\\%]+)|(?<attr>\[)(?<atype>class|id|style|type|role)(?<mark>\^|\$|\*)?=(?<astr>.+?)\]|^(?<tag1>[\w\-\\%]+)|[,\s>\+~\(\)\]\|](?<tag2>[\w\-\\%]+)`u', $_s, $item, PREG_OFFSET_CAPTURE, $offset)){
+                        if(!empty($item['id'][0])){
+                            $name = $item['iname'][0];
+                            if(!isset(self::$jsaddlist[$name]) && !isset(self::$id[$name])){
+                                $sel = preg_replace( '`(' . preg_quote($s) . ')(,|$)`u', '$2', $sel, 1 );
+                                break;
+                            }                             
+                        } elseif(!empty($item['class'][0])){
+                            $name = $item['cname'][0];
+                            if(!isset(self::$jsaddlist[$name]) && !isset(self::$class[$name])){
+                                $sel = preg_replace( '`(' . preg_quote($s) . ')(,|$)`u', '$2', $sel, 1 );
+                                break;
+                            }
+                        } elseif(!empty($item['tag1'][0]) || !empty($item['tag2'][0])){                            
+                            $name = strtolower( (empty($item['tag1'][0]))? $item['tag2'][0] : $item['tag1'][0] );
+                            if(!isset(self::$jsaddlist[$name]) && !isset(self::$tag[$name])){
+                                $sel = preg_replace( '`(' . preg_quote($s) . ')(,|$)`u', '$2', $sel, 1 );
+                                break;
+                            }                            
+                        } elseif(!empty($item['attr'][0])){
+                            $before = $after  = '';
+                            if($item['mark'][0] == '^'){
+                                $before = $item['mark'][0];
+                            } elseif($item['mark'][0] == '$'){
+                                $after  = $item['mark'][0];
+                            } elseif($item['mark'][0] != '*'){
+                                $before = '^';
+                                $after  = '$';
+                            }
+                            if ( strpos(self::$attrlist[ $item['atype'][0] ], $before. trim($item['astr'][0], ' \'"') . $after ) === false){
+                                $sel = preg_replace( '`(' . preg_quote($s) . ')(,|$)`u', '$2', $sel, 1 );
+                                break;
+                            }                            
+                        }
+                        $offset = $item[0][1] + strlen($item[0][0]);
+                    }
+                }                    
+            }, explode(',', $_sel));
+            if(!empty($sel)){
+                $sel = trim( preg_replace_callback( '`(,|\s){2,}`su', function($_s){ return $_s[1]; }, $sel ), ' ,');                  
+            }
+          
+            if(empty($sel) || empty($pv)){
+                $result = $before . $after;
+            } elseif(strpos($sel, '@') !== false && preg_match("#@(\-[\w]+\-)?(keyframes|counter\-style)\s(.+)$#", $sel, $aid)) {
+                self::$attrlist['atref'][$aid[3]] = $aid[2];                            
+                $result = $before . $sel . '{'. $pv .'}' . $after;
+            } elseif(strpos($pv, '{') !== false) {
+                $nest = preg_replace_callback( '`([^{]*?)(\{((?>[^{}]+)|(?2))*\})`', function($_css){ return self::tree_shaking($_css[0]); }, $pv );                        
+                if(empty($nest)){
+                    $result = $before . $after;
+                } else {
+                    $result = $before . $sel . '{'. $nest .'}'  . $after;
                 }
             } else {
-                $newsel .= substr($selector, $ofset);
-                break;
+                $result = $before . $sel . '{'. $pv .'}' . $after;
             }
-        }
-        return $newsel;
-    }
-
-    //selector 内の :not :where :is :has 疑似クラスを復元
-    public static function restore_pseudo($selector, &$temp) {
-        if(!empty($temp)){
-            $selector = preg_replace_callback( '#(:not|:where|:is|:has)\((.*?)\)#u', function($match) use(&$temp) {
-                $kv = $match[2];
-                if(!empty($kv) && isset($temp[ $kv ])){
-                    $kv = $temp[ $kv ];
-                }
-                return $match[1] . '(' . $kv . ')';
-            }, $selector);
-        }
-        return $selector;
-    }
-
-    //CSS から未使用の id, class, tag を含む定義を削除
-    private static function tree_shaking($css, $customcsslist=array(), $atkey='') {
-        $ncss = preg_replace_callback( self::SHAKING_PATTERN, function($mstyle) use(&$customcsslist, &$atkey) {
-            $data = $mstyle[0];
-            if(!empty($mstyle['atname'])){
-                $atkey = md5(trim($mstyle['pref'] . $mstyle['atname']));
-                $atcss = self::tree_shaking( $mstyle['atstyle'], $customcsslist, $atkey );
-                $atkey = ''; //key clear
-                $data  = (!empty($atcss))? '@' . trim($mstyle['pref'] . $mstyle['atname']) . '{' . $atcss . '}' : '';
-
-            } elseif(!empty($mstyle['sel'])) {
-                $sel = $mstyle['sel'];
-                $pv  = $mstyle['pv'];
-                if(!empty($customcsslist)){
-                    //tree shaking 前に上書きカスタムCSSとの重複あれば該当プロパティを削除
-                    $atkey = (!empty($atkey))? $atkey : 0;
-                    $skey  = md5(trim($sel));
-                    if(!empty($customcsslist[$atkey][$skey])){
-                        $_pv  = array_map("trim", preg_split("|[:;]|", $pv));
-                        $pcnt= count($_pv);
-                        for($i=0; $i<$pcnt; $i += 2){
-                            if(!empty($_pv[$i]) && isset( $customcsslist[ $atkey ][ $skey ][ $_pv[$i] ] )){
-                                $pv = preg_replace( '/(^|;|\s)(' . preg_quote($_pv[$i]) . ')\s?:.*?(url\([^\)]+?\).*?)?(;|$)/u', '$1', $pv, 1 );
-                            }
-                        }
-                        if(!empty($pv)){
-                            $pv = preg_replace('/\s+/su', ' ', $pv);
-                            $pv = trim($pv);
-                        }
-                    }
-                }
-                $pattern = array( 'id'       => '|(#)([\w\-\\%]+)|u',
-                                  'class'    => '|(\.)([\w\-\\%]+)|u',
-                                  'tag'      => '/(^|[,\s>\+~\(\)\]\|])([\w\-]+)/iu',
-                                );
-
-                $pseudo = array();
-                $sel = self::evacuate_pseudo($sel, $pseudo);
-                $slist = array_map("trim", explode(',', $sel));
-                foreach ($slist as $s) {
-                    //selector の判定条件から :not :where :is :has を除外 ($_s で判定して削除時は $s で行う)
-                    $_s = $s;
-                    foreach (array(':not',':where',':is',':has') as $psd) {
-                        if(strpos($_s, $psd) !== false){
-                            $_s = preg_replace("&$psd\(.+?\)&", '', $_s );
-                        }
-                    }
-                    foreach (array('id','class','tag') as $item) {
-                        if(!empty($_s) && preg_match_all( $pattern[$item], $_s, $match)){
-                            foreach ($match[2] as $v) {
-                                //$jsaddlist 登録名が含まれていれば削除しない（処理を簡略化するため上位層のセレクタのみで判定）
-                                if(isset(self::$jsaddlist[$v]))
-                                    break;
-
-                                //$cmplist 登録名に含まれていなければ削除
-                                $delfg = false;
-                                if(!isset(self::$cmplist[$item][$v]) && !preg_match('/^[0-9]+/', $v)){
-                                    $delfg = true;
-                                } elseif($item === 'tag' && preg_match('#\[type\s?=\s?[\'"](.+?)[\'"]#', $_s, $type)){
-                                    if(!isset(self::$cmplist['type'][$type[1]])){
-                                        $delfg = true;
-                                    }
-                                }
-                                if($delfg){
-                                    //$s 内に data-type core/xxxx があると / のマッチでエラーとなるのでデリミタを / から & へ変更
-                                    $sel = preg_replace( '&(' . preg_quote($s) . ')(,|$)&u', '$2', $sel, 1 );
-                                    $_s  = '';
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                    if(!empty($_s)){
-                        // id / css 属性セレクタ限定の部分マッチチェック
-                        if(preg_match_all( '#\[(?<attr>class|id)(?<type>\^|\$|\*)?=["\'](?<str>[\w\-]+?)["\'].*?\]#', $_s, $smatch, PREG_SET_ORDER)){
-                            foreach ($smatch as $item) {
-                                $attr = $item['attr'];
-                                $type = $item['type'];
-                                if($type == '^'){
-                                    $str = $type . $item['str'];
-                                } elseif($type == '$'){
-                                    $str = $item['str'] . $type;
-                                } elseif($type == '*'){
-                                    $str = $item['str'];
-                                } else {
-                                    $str = '^' . $item['str'] . '$';
-                                }
-                                //属性セレクタにマッチしなければ削除　
-                                if ( ($ret = strpos(self::$cmplist[ $attr . '_str' ], $str )) === false){
-                                    $sel = preg_replace( '&(' . preg_quote($s) . ')(,|$)&u', '$2', $sel, 1 );
-                                    $_s  = '';
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                }
-                $sel = self::restore_pseudo($sel, $pseudo);
-
-                if(!empty($sel)){
-                    $sel = preg_replace('/,+/su', ',', $sel);
-                    $sel = preg_replace('/\s+/su', ' ', $sel);
-                    $sel = trim($sel);
-                    $sel = trim($sel, ',');
-                }
-                $data = (!empty($sel) && !empty($pv))? $sel . '{'. $pv .'}' : '';
-            }
-            return $data;
+            return $result;
         }, $css);
-        return $ncss;
+        return $mincss;
     }
 
-    //未使用変数定義の削除（tree_shaking 実行後に実施する）
-    //CSSファイルが分割されていると使われている変数定義まで削除の可能性があるので amp-custom style に限定した使用を想定
+    //Delete unused variable definitions (implemented after executing tree_shaking)
+    //Note that if the CSS file is split, even the variable definitions used may be deleted.
     public static function tree_shaking4var($css) {
-        $varlist = array();
-        if(preg_match_all( "/var\((\-\-[^\s\),]+?)[\s\),]/iu", $css, $vmatches)){
-            foreach ($vmatches[1] as $v) {
-                $v = trim($v);
-                if(!isset($varlist[$v])){
-                    $varlist[$v] = 1;
-                }
-            }
+        $varlist = (preg_match_all( "/var\((\-\-[^\s\),]+?)[\s\),]/u", $css, $vmatches))? array_flip( $vmatches[1] ) : array();
+        if(!empty(self::$attrlist['style'])){
+            $inline  = (preg_match_all( "/var\((\-\-[^\s\),]+?)[\s\),]/u", self::$attrlist['style'], $vmatches))? array_flip( $vmatches[1] ) : array();
+            $varlist = array_merge( $varlist, $inline);
         }
-        //url() 定義時は文字列中に ; が含まれている場合あり
-        $pattern = '!(\-\-[\w\-]+?):.*?(url\([^\)]+?\).*?)?([;\}])!u';
-        $css = preg_replace_callback( $pattern, function($match) use(&$varlist) {
-            $vdef = $match[0];
-            $var  = trim($match[1]);
-            if(!isset($varlist[ $var ])){
-                $vdef = ($match[3] === '}')? '}' : '';
+        return preg_replace_callback( '`(\-\-[\w\-]+?):.*?(url\([^\)]+?\).*?)?([;\}])`u', function($match) use($varlist) {
+            if(!isset($varlist[ trim($match[1]) ])){
+                $match[0] = ($match[3] === '}')? '}' : '';
             }
-            return $vdef;
-        }, $css);
-        return $css;
+            return $match[0];
+        }, $css);            
     }
 
     /*=============================================================
-     * CSS 内のコメント、改行、空白等を削除するだけのシンプルな縮小化
+     * Simple minification that just removes comments, line breaks, whitespace, etc. in CSS
      */
     public static function simple_minify( $css ) {
-        $css = preg_replace('!/\*[^*]*\*+([^/][^*]*\*+)*/!', '', $css );
-        $css = str_replace(array("\r", "\n"), '', $css);
-        $css = str_replace("\t", ' ', $css);
-        $css = preg_replace('/\s+/su', ' ', $css);
-        $css = preg_replace('/\s([\{\}=,\)\/;>])/', '$1', $css);
-        $css = preg_replace('/([\{\}:=,\(\/!;])\s/', '$1', $css);
-        return $css;
+        $css = preg_replace('`/\*[^*]*\*+([^/][^*]*\*+)*/`', '', $css );
+        $css = preg_replace('`\s{2,}`su', ' ', str_replace(array("\r", "\n", "\t"), ' ', $css));
+        return preg_replace_callback('`(\s(?<fs>[\{\}=,\)\/;>])|(?<rs>[\{\}:=,\(\/!;])\s)`su', function($_s) { return (!empty($_s['fs']))? $_s['fs'] : $_s['rs']; }, $css);
     }
 
     /*=============================================================
-     * css(simple_minify済)の未使用 id, class, tag に関する定義を取り除き縮小化
+     * Remove CSS data including unused id / class / tag
+     * 
+     * $css         : CSS for tree shaking (simple_minified normalized CSS data)
+     * $html        : HTML of the target page
+     * $jsaddlist   : Register IDs and classes added by JS after DOM loading (excludes tree shaking)
+     * $varminify   : Remove unused CSS variable definitions
+     * $atrefminify : Remove unused referrer definitions such as @atrule keyframes 
      */
-    public static function extended_minify($css, $html, $jsaddlist=array(), $varminify=false, $customcsslist=array()) {
-        self::$jsaddlist = array();
-        if(!empty($jsaddlist)){   //JS によりDOMロード後に追加される ID や class 等が除外されなくするための名前の事前登録用
-            foreach ($jsaddlist as $tag) {
-                if(!isset(self::$jsaddlist[$tag])){
-                    self::$jsaddlist[$tag] = 1;
+    public static function extended_minify($css, $html, $jsaddlist=array(), $varminify=false, $atrefminify=false) {
+
+        self::$jsaddlist = (!empty($jsaddlist))? array_flip( $jsaddlist ) : array(); 
+        
+        //Extract tag, id, class from HTML
+        if(empty(self::$is_parse)){
+            self::$is_parse = true;
+            self::$id    = array();
+            self::$class = array();
+            self::$style = array();
+            self::$type  = array();
+            self::$role  = array();
+            self::$tag   = array_flip( array('html','head','body','title','style','meta','link','script','noscript') );        
+            
+            preg_replace_callback( '`<style(?<catrb>[^>]*?)>|<script(?<satrb>[^>]*?)>|<(?<tag>[\w\-]+)(?<tatrb>[^>]*?)>`s', function($item){
+                $atrb = '';
+                if(!empty($item['catrb'])) {
+                    $atrb = trim($item['catrb']);
+                } elseif(!empty($item['satrb'])) {
+                    $atrb = trim($item['satrb']);
+                } elseif(!empty($item['tag'])){
+                    $atrb = trim($item['tatrb']);
+                    self::$tag[strtolower($item['tag'])] = 1;
                 }
-            }
+                if(!empty($atrb)){
+                    preg_replace_callback( '`(id|class|style|type|role)\s?=\s?([\'"])(.+?)\2`u', function($_atrb){
+                        $sep = ($_atrb[1] === 'style')? ';' : ' ';
+                        array_map( function($_s) use($_atrb) { self::${$_atrb[1]}[trim($_s)] = 1; }, explode($sep, trim($_atrb[3], ' ;')));
+                        return $_atrb[0];
+                    }, $atrb );
+                }
+                return $item[0];                
+            }, $html );
+            //for id / css / inline style / type /role attribute selector matching
+            self::$attrlist['id']    = '^' . implode("$^", array_keys(self::$id)) . '$';
+            self::$attrlist['class'] = '^' . implode("$^", array_keys(self::$class)) . '$';            
+            self::$attrlist['style'] = '^' . implode("$^", array_keys(self::$style)) . '$';            
+            self::$attrlist['type']  = '^' . implode("$^", array_keys(self::$type)) . '$';            
+            self::$attrlist['role']  = '^' . implode("$^", array_keys(self::$role)) . '$';            
         }
-
-        if(empty(self::$cmplist['parse'])){
-            self::$cmplist['parse'] = true;
-            self::$cmplist['id_str'] = '';
-            self::$cmplist['class_str'] = '';
-
-			$inidata           = array(
-				'id'    => array(),
-				'class' => array(
-					'device-mobile',
-					'header_scrolled',
-					'active',
-					'menu-open',
-					'vk-mobile-nav-menu-btn',
-					'vk-mobile-nav-open',
-					'vk-menu-acc-active',
-					'acc-parent-open',
-					'acc-btn',
-					'acc-btn-open',
-					'acc-btn-close',
-					'acc-child-open',
-					'carousel-item-left',
-					'carousel-item-next',
-					'carousel-item-right',
-					'carousel-item-prev',
-					'form-control',
-					'btn',
-					'btn-primary',
-					'.vk_post_imgOuter a:hover .card-img-overlay::after',
-				),
-				'tag'   => array(
-					'html',
-					'head',
-					'body',
-					'title',
-					'style',
-					'meta',
-					'link',
-					'script',
-					'noscript',
-				),
-			);
-			$inidata           = apply_filters( 'css_tree_shaking_exclude', $inidata );
-
-            foreach (array('id','class','tag') as $item) {
-                foreach ($inidata[$item] as $tag) {
-                    if(!isset(self::$cmplist[$item][$tag])){
-                        self::$cmplist[$item][$tag] = 1;
+        
+        if( substr_count($css, '{') === substr_count($css, '}') ){
+            $css = preg_replace_callback( '`([^{]*?)(\{((?>[^{}]+)|(?2))*\})`', function($_css){ return self::tree_shaking($_css[0]); }, $css );            
+            if($atrefminify && !empty(self::$attrlist['atref'])){
+                foreach(self::$attrlist['atref'] as $aid => $type){
+                    if(!preg_match("`:$aid(\s|;)`", $css)){
+                        $css = preg_replace("`@((\-[\w]+\-)?$type\s$aid)(\{((?>[^{}]+)|(?3))*\})`", '', $css, 1);
                     }
-                }
+                }                
             }
-            //HTML から使用している tag, id, class 抽出
-            $pattern = '#<style(?<catrb>.*?)>.*?<\/style|<script(?<satrb>.*?)>.*?<\/script|<!--.+?-->|<(?<tag>[\w\-]+)(?<tatrb>.*?)>#si';
-            if(preg_match_all( $pattern, $html, $items, PREG_SET_ORDER)){
-                foreach ($items as $item) {
-                    $atrb = '';
-                    if(!empty($item['tag'])){
-                        if(!isset(self::$cmplist['tag'][$item['tag']])){
-                            self::$cmplist['tag'][$item['tag']] = 1;
-                        }
-                        $atrb = $item['tatrb'];
-                        //type ほぼ input のみと思われる
-                        if(preg_match('#type\s?=\s?[\'"](.+?)[\'"]#u', $atrb, $type)){
-                            if(!isset(self::$cmplist['type'][$type[1]])){
-                                self::$cmplist['type'][$type[1]] = 1;
-                            }
-                        }
-                    } elseif(!empty($item['catrb'])) {
-                        $atrb = $item['catrb'];
-                    } elseif(!empty($item['satrb'])) {
-                        $atrb = $item['satrb'];
-                    }
-                    $atrb = trim($atrb);
-                    if(!empty($atrb)){
-                        if(preg_match('#id\s?=\s?[\'"](.+?)[\'"]#u', $atrb, $id)){
-                            $arr = array_map("trim", explode(' ', $id[1]));
-                            foreach($arr as $id){
-                                $id = trim($id);
-                                if(!isset(self::$cmplist['id'][$id])){
-                                    self::$cmplist['id'][$id] = 1;
-                                    self::$cmplist['id_str'] .= '^' . $id . '$';
-                                }
-                            }
-                        }
-                        if(preg_match('#class\s?=\s?[\'"](.+?)[\'"]#u', $atrb, $cls)){
-                            $arr = array_map("trim", explode(' ', $cls[1]));
-                            foreach($arr as $cls){
-                                $cls = trim($cls);
-                                if(!isset(self::$cmplist['class'][$cls])){
-                                    self::$cmplist['class'][$cls] = 1;
-                                    self::$cmplist['class_str'] .= '^' . $cls . '$';
-                                }
-                            }
-                        }
-                    }
-                }
+            if($varminify){
+                $css = self::tree_shaking4var( $css );
             }
-        }
-        $css = self::tree_shaking( $css, $customcsslist );
-        if($varminify){
-            $css = self::tree_shaking4var( $css );
         }
         return $css;
     }


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

https://github.com/vektor-inc/vk-blocks-pro/issues/2229

## どういう変更をしたか？

- Tree Shaking を更新しました。

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？
⇒ ライブラリを更新しただけなので省略

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

- テーマは BizVektor を有効化
- プラグインは VK Blocks Pro のみ有効化
- VK Blocks Pro のブランチは update/css-optimize026 に切り替えた状態
- VK Blocks Pro の composer.json の require の vektor-inc/vk-css-optimize のバージョンは dev-update/tree-shaking/3.2 に書き換え

上記の状態で
- VK Blocks Pro の composer.lock と vendor フォルダを削除したあとで composer install 
- vk-blocks-build-css がソースコード上でインライン出力するのを確認
- 下記が正常動作するのを確認

  - 非表示設定
  - スライダーブロック
  - アコーディオンブロック

以上を確認しました。

## 確認URL

ローカル環境

## レビュワーに回す前の確認事項

- [ ] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

- テーマは BizVektor を有効化
- プラグインは VK Blocks Pro のみ有効化
- VK Blocks Pro のブランチは update/css-optimize026 に切り替えた状態
- VK Blocks Pro の composer.json の require の vektor-inc/vk-css-optimize のバージョンは dev-update/tree-shaking/3.2 に書き換え


上記の状態で
- VK Blocks Pro の composer.lock と vendor フォルダを削除したあとで composer install 
- vk-blocks-build-css がソースコード上でインライン出力するのを確認
- 下記が正常動作するのを確認

  - 非表示設定
  - スライダーブロック
  - アコーディオンブロック

以上を確認お願いします。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
